### PR TITLE
chore(Jenkinsfile): specify node of type 'linux'

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-node {
+node('linux') {
  stage 'Checkout'
  checkout scm
 


### PR DESCRIPTION
as we now have windows node(s) that this pipeline may not run on

cc @joshua-anderson
