### PR TITLE
fix(Dockerfile): run container as root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,6 @@ FROM gcr.io/google_containers/ubuntu-slim:0.3
 ENV BATS_VERSION 0.4.0
 ENV SHELLCHECK_VERSION 0.4.3
 
-RUN addgroup --gid 999 shelly
-RUN adduser --system \
-	--shell /bin/bash \
-	--disabled-password \
-	--gid 999 \
-	--uid 999 \
-	shelly
-
 RUN apt-get update -q \
 	&& apt-get install -y -q --no-install-recommends bash make curl ca-certificates jq \
 	&& curl -L https://s3-us-west-2.amazonaws.com/get-deis/shellcheck-${SHELLCHECK_VERSION}-linux-amd64 -o /usr/local/bin/shellcheck \
@@ -20,5 +12,3 @@ RUN apt-get update -q \
 	&& tar -x -z -f "/tmp/v${BATS_VERSION}.tar.gz" -C /tmp/ \
 	&& bash "/tmp/bats-${BATS_VERSION}/install.sh" /usr/local \
 	&& rm -rf /tmp/*
-
-USER shelly


### PR DESCRIPTION
Trying to run `make test` in the jenkins-jobs repository uses this image, but it fails with permissions errors. Essentially we bind-mount `/workdir` and make the current user `shelly`, but that user doesn't map to anything useful or writeable. Just running as the default "root" user works around the issue.