### PR TITLE
feat(Dockerfile): update shellcheck to v0.4.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/google_containers/ubuntu-slim:0.3
 
 ENV BATS_VERSION 0.4.0
-ENV SHELLCHECK_VERSION 0.4.3
+ENV SHELLCHECK_VERSION v0.4.6
 
 RUN addgroup --gid 999 shelly
 RUN adduser --system \
@@ -13,7 +13,7 @@ RUN adduser --system \
 
 RUN apt-get update -q \
 	&& apt-get install -y -q --no-install-recommends bash make curl ca-certificates jq \
-	&& curl -L https://s3-us-west-2.amazonaws.com/get-deis/shellcheck-${SHELLCHECK_VERSION}-linux-amd64 -o /usr/local/bin/shellcheck \
+	&& curl -L https://deisbuildartifacts.blob.core.windows.net/shellcheck/shellcheck-${SHELLCHECK_VERSION}-linux-amd64 -o /usr/local/bin/shellcheck \
 	&& chmod +x /usr/local/bin/shellcheck \
 	&& curl -o "/tmp/v${BATS_VERSION}.tar.gz" -L \
 		"https://github.com/sstephenson/bats/archive/v${BATS_VERSION}.tar.gz" \


### PR DESCRIPTION
Also moves the binary artifact to a stable location in Azure blob storage.

Building a static binary of `shellcheck` is the trickiest part of this. In addition to the regular [build instructions](https://github.com/koalaman/shellcheck#compiling-from-source), I did this to get a small binary that runs on Alpine as well as Ubuntu:

```shell
$ cabal install --disable-executable-dynamic --disable-shared --ghc-option=-optl=-static --ghc-option=-optl=-pthread
$ upx --ultra-brute shellcheck
```